### PR TITLE
Compression pygzip and pybzip2 allowed

### DIFF
--- a/lib/rbarman/wal_file.rb
+++ b/lib/rbarman/wal_file.rb
@@ -81,6 +81,8 @@ module RBarman
 
     def compression=(compression)
       if compression != :gzip and
+        compression != :pygzip and
+        compression != :pybzip2 and
         compression != :bzip2 and
         compression != :none and
         compression != :custom


### PR DESCRIPTION
Since Barman 1.6.0 released, pygzip and pybzip2 compressors are allowed
